### PR TITLE
Add annotations to tar export

### DIFF
--- a/cmd/convertor/builder/builder.go
+++ b/cmd/convertor/builder/builder.go
@@ -296,6 +296,9 @@ func (b *graphBuilder) buildOne(ctx context.Context, src v1.Descriptor, tag bool
 	engineBase.reserve = b.Reserve
 	engineBase.noUpload = b.NoUpload
 	engineBase.dumpManifest = b.DumpManifest
+	if _, ok := b.Resolver.(*FileBasedResolver); ok {
+		engineBase.tarExport = true
+	}
 
 	var engine builderEngine
 	switch b.Engine {

--- a/cmd/convertor/builder/builder_engine.go
+++ b/cmd/convertor/builder/builder_engine.go
@@ -116,6 +116,7 @@ type builderEngineBase struct {
 	noUpload     bool
 	dumpManifest bool
 	referrer     bool
+	tarExport    bool
 }
 
 func (e *builderEngineBase) isGzipLayer(ctx context.Context, idx int) (bool, error) {
@@ -171,6 +172,7 @@ func (e *builderEngineBase) mediaTypeImageLayer() string {
 }
 
 func (e *builderEngineBase) uploadManifestAndConfig(ctx context.Context) (specs.Descriptor, error) {
+	shouldUploadBlob := !e.noUpload || e.tarExport
 	cbuf, err := json.Marshal(e.config)
 	if err != nil {
 		return specs.Descriptor{}, err
@@ -180,7 +182,7 @@ func (e *builderEngineBase) uploadManifestAndConfig(ctx context.Context) (specs.
 		Digest:    digest.FromBytes(cbuf),
 		Size:      (int64)(len(cbuf)),
 	}
-	if !e.noUpload {
+	if shouldUploadBlob {
 		if err = uploadBytes(ctx, e.pusher, e.manifest.Config, cbuf); err != nil {
 			return specs.Descriptor{}, errors.Wrapf(err, "failed to upload config")
 		}
@@ -204,7 +206,7 @@ func (e *builderEngineBase) uploadManifestAndConfig(ctx context.Context) (specs.
 		Digest:    digest.FromBytes(cbuf),
 		Size:      (int64)(len(cbuf)),
 	}
-	if !e.noUpload {
+	if shouldUploadBlob {
 		if err = uploadBytes(ctx, e.pusher, manifestDesc, cbuf); err != nil {
 			return specs.Descriptor{}, errors.Wrapf(err, "failed to upload manifest")
 		}

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -177,7 +177,8 @@ func (e *overlaybdBuilderEngine) UploadLayer(ctx context.Context, idx int) error
 		label.OverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
 		label.OverlayBDBlobFsType: e.fstype,
 	}
-	if !e.noUpload {
+	shouldUploadBlob := !e.noUpload || e.tarExport
+	if shouldUploadBlob {
 		if err := uploadBlob(ctx, e.pusher, path.Join(layerDir, commitFile), desc); err != nil {
 			return errors.Wrapf(err, "failed to upload layer %d", idx)
 		}
@@ -467,7 +468,8 @@ func (e *overlaybdBuilderEngine) uploadBaseLayer(ctx context.Context) (specs.Des
 			label.OverlayBDBlobFsType: e.fstype,
 		},
 	}
-	if !e.noUpload {
+	shouldUploadBlob := !e.noUpload || e.tarExport
+	if shouldUploadBlob {
 		if err = uploadBlob(ctx, e.pusher, tarFile, baseDesc); err != nil {
 			return specs.Descriptor{}, errors.Wrapf(err, "failed to upload baselayer")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: Adds missing overlaybd annotations to the exported tar. These are needed to properly detect the image format.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
