### PR TITLE
Bump golang version in ci action

### DIFF
--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.22.0"
+  GO_VERSION: "1.23.0"
   OBD_VERSION: "1.0.12"
 
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**: Bumps ci.yml golang version to match go.mod. Without this the ci action is failing with `go: go.mod requires go >= 1.23.0 (running go 1.22.0; GOTOOLCHAIN=local)`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
