### PR TITLE
Check the parent snapshot to identify the writable type

### DIFF
--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -413,8 +413,26 @@ func (o *snapshotter) getWritableType(ctx context.Context, id string, info snaps
 			log.G(ctx).Debugf("OverlayBD labels detected for snapshot %s - using overlaybd (rwMode: %s)", id, o.rwMode)
 			return rwMode(o.rwMode)
 		}
+
 		// Fallback to checking the filesystem if labels are not present
-		stype, err := o.identifySnapshotStorageType(ctx, id, info)
+		// For write capability decisions, check the parent's storage type directly
+		var stype storageType
+		var err error
+		if id != "" && info.Parent != "" && o.isPrepareRootfs(info) {
+			// Get parent info and check its storage type
+			if _, parentInfo, _, err := storage.GetInfo(ctx, info.Parent); err == nil {
+				log.G(ctx).Debugf("getWritableType: checking parent snapshot %s for overlaybd format (child: %s)", id, info.Name)
+				stype, err = o.identifySnapshotStorageType(ctx, id, parentInfo)
+			} else {
+				// Fallback in case of error - probably should not happen.
+				log.G(ctx).Warnf("getWritableType: failed to get parent info for %s, checking child info: %v", info.Parent, err)
+				stype, err = o.identifySnapshotStorageType(ctx, id, info)
+			}
+		} else {
+			// Standard case: check the snapshot's own storage type
+			stype, err = o.identifySnapshotStorageType(ctx, id, info)
+		}
+
 		if err == nil && (stype == storageTypeLocalBlock || stype == storageTypeRemoteBlock) {
 			log.G(ctx).Debugf("OverlayBD filesystem detected for snapshot %s - using overlaybd (rwMode: %s)", id, o.rwMode)
 			return rwMode(o.rwMode)


### PR DESCRIPTION
**What this PR does / why we need it**:

**What**
Changes getWritableType() to look at the *parent* snapshot's filesystem instead of the child's, which doesn't even exist at this point.

**Why**
When creating sandboxes/containers from overlaybd pause images, the first creation works correctly but subsequent attempts fall back to overlayfs mode instead of using overlaybd. 

The getWritableType() function was checking the child snapshot's labels and filesystem for overlaybd metadata, but the child snapshot doesn't have a label, and the child snapshot directories don't exist yet at this point. 


**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
