### PR TITLE
Revert "Mount overlaybd devices in journal mode"

### DIFF
--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -1579,7 +1579,6 @@ func (o *snapshotter) basedOnBlockDeviceMount(ctx context.Context, s storage.Sna
 				Options: []string{
 					rwflag,
 					"discard",
-					"data=journal",
 				},
 			},
 		}, nil

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -450,7 +450,7 @@ func (o *snapshotter) attachAndMountBlockDevice(ctx context.Context, snID string
 				} else {
 					switch fstype {
 					case "ext4":
-						mountOpts = "discard,data=journal"
+						mountOpts = "discard"
 					case "xfs":
 						mountOpts = "nouuid,discard"
 					default:


### PR DESCRIPTION
This reverts commit 807f5a76fb4eafea4dbd0c016fc26c5f08982b62.


**What this PR does / why we need it**:
<Issue>
<img width="1262" height="561" alt="image" src="https://github.com/user-attachments/assets/e8d8b35a-e5f2-419b-96a7-d7e48c593ef4" />


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
